### PR TITLE
fix(ci): resolve Portal typecheck errors and Server ruff lint failures

### DIFF
--- a/portal/app/composables/useApi.ts
+++ b/portal/app/composables/useApi.ts
@@ -9,6 +9,10 @@
 import type { FetchOptions } from 'ofetch'
 import { useAuthStore } from '../stores/auth'
 
+type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'HEAD' | 'OPTIONS'
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type RequestBody = Record<string, any> | BodyInit | null | undefined
+
 export function useApi() {
   const config = useRuntimeConfig()
   const baseURL = config.public.apiBaseUrl as string
@@ -35,6 +39,7 @@ export function useApi() {
       return await $fetch<T>(path, {
         baseURL,
         ...options,
+        method: options.method as HttpMethod,
         headers,
       })
     } catch (error: unknown) {
@@ -51,15 +56,15 @@ export function useApi() {
     return request<T>(path, { method: 'GET', query })
   }
 
-  function post<T = unknown>(path: string, body?: unknown) {
+  function post<T = unknown>(path: string, body?: RequestBody) {
     return request<T>(path, { method: 'POST', body })
   }
 
-  function put<T = unknown>(path: string, body?: unknown) {
+  function put<T = unknown>(path: string, body?: RequestBody) {
     return request<T>(path, { method: 'PUT', body })
   }
 
-  function patch<T = unknown>(path: string, body?: unknown) {
+  function patch<T = unknown>(path: string, body?: RequestBody) {
     return request<T>(path, { method: 'PATCH', body })
   }
 

--- a/portal/app/pages/alerts/index.vue
+++ b/portal/app/pages/alerts/index.vue
@@ -213,8 +213,10 @@ const filteredEvents = computed(() => {
   return result
 })
 
-function severityColor(severity: string): string {
-  const map: Record<string, string> = {
+type BadgeColor = 'primary' | 'secondary' | 'success' | 'info' | 'warning' | 'error' | 'neutral'
+
+function severityColor(severity: string): BadgeColor {
+  const map: Record<string, BadgeColor> = {
     low: 'success',
     medium: 'warning',
     high: 'warning',
@@ -223,8 +225,8 @@ function severityColor(severity: string): string {
   return map[severity] || 'neutral'
 }
 
-function eventStatusColor(status: string): string {
-  const map: Record<string, string> = {
+function eventStatusColor(status: string): BadgeColor {
+  const map: Record<string, BadgeColor> = {
     active: 'error',
     acknowledged: 'info',
     resolved: 'success',

--- a/portal/app/pages/assets/index.vue
+++ b/portal/app/pages/assets/index.vue
@@ -192,8 +192,10 @@ function assetTypeLabel(type: string) {
   return typeLabels[type] || type
 }
 
-function typeColor(type: string): string {
-  const map: Record<string, string> = {
+type BadgeColor = 'primary' | 'secondary' | 'success' | 'info' | 'warning' | 'error' | 'neutral'
+
+function typeColor(type: string): BadgeColor {
+  const map: Record<string, BadgeColor> = {
     cnc: 'info',
     robot: 'secondary',
     conveyor: 'info',

--- a/portal/app/pages/dashboard.vue
+++ b/portal/app/pages/dashboard.vue
@@ -251,8 +251,10 @@ function severityDotClass(severity: string) {
   return map[severity] || 'bg-gray-400'
 }
 
-function statusBadgeColor(status: string): string {
-  const map: Record<string, string> = {
+type BadgeColor = 'primary' | 'secondary' | 'success' | 'info' | 'warning' | 'error' | 'neutral'
+
+function statusBadgeColor(status: string): BadgeColor {
+  const map: Record<string, BadgeColor> = {
     acknowledged: 'info',
     resolved: 'success',
     suppressed: 'neutral',

--- a/portal/app/pages/devices/[id].vue
+++ b/portal/app/pages/devices/[id].vue
@@ -256,8 +256,10 @@ const telemetryPoints = ref<TelemetryPoint[]>([])
 const deviceEvents = ref<DeviceEvent[]>([])
 const errorMsg = ref('')
 
-function statusColor(status: string): string {
-  const map: Record<string, string> = {
+type BadgeColor = 'primary' | 'secondary' | 'success' | 'info' | 'warning' | 'error' | 'neutral'
+
+function statusColor(status: string): BadgeColor {
+  const map: Record<string, BadgeColor> = {
     active: 'success',
     inactive: 'neutral',
     maintenance: 'warning',
@@ -276,8 +278,8 @@ function severityDot(severity: string) {
   return map[severity] || 'bg-gray-400'
 }
 
-function eventStatusColor(status: string): string {
-  const map: Record<string, string> = {
+function eventStatusColor(status: string): BadgeColor {
+  const map: Record<string, BadgeColor> = {
     active: 'error',
     acknowledged: 'info',
     resolved: 'success',

--- a/portal/app/pages/devices/index.vue
+++ b/portal/app/pages/devices/index.vue
@@ -189,8 +189,10 @@ const filteredDevices = computed(() => {
   return result
 })
 
-function statusColor(status: string): string {
-  const map: Record<string, string> = {
+type BadgeColor = 'primary' | 'secondary' | 'success' | 'info' | 'warning' | 'error' | 'neutral'
+
+function statusColor(status: string): BadgeColor {
+  const map: Record<string, BadgeColor> = {
     active: 'success',
     inactive: 'neutral',
     maintenance: 'warning',

--- a/server/assets/tests.py
+++ b/server/assets/tests.py
@@ -1,6 +1,7 @@
 from datetime import timedelta
 
 from django.contrib.auth.models import User
+from django.db import IntegrityError
 from django.test import TestCase
 from django.utils import timezone
 from rest_framework import status
@@ -11,7 +12,6 @@ from devices.models import Site
 
 from .models import Asset, AssetCycle
 from .serializers import AssetSerializer
-
 
 # ---------------------------------------------------------------------------
 # Model tests
@@ -42,7 +42,7 @@ class AssetModelTests(TestCase):
             make="Kuka",
             model="KR 10",
         )
-        with self.assertRaises(Exception):
+        with self.assertRaises(IntegrityError):
             Asset.objects.create(
                 asset_id="DOOR-001",
                 site=self.site,
@@ -106,7 +106,9 @@ class AssetSerializerTests(TestCase):
         # Use annotated queryset (as the viewset does) for the count field
         from django.db.models import Count
 
-        asset = Asset.objects.annotate(cycle_count=Count("cycles")).get(pk=self.asset.pk)
+        asset = Asset.objects.annotate(cycle_count=Count("cycles")).get(
+            pk=self.asset.pk
+        )
         serializer = AssetSerializer(asset)
         self.assertEqual(serializer.data["cycle_count"], 1)
 

--- a/server/devices/apps.py
+++ b/server/devices/apps.py
@@ -6,4 +6,4 @@ class DevicesConfig(AppConfig):
     name = "devices"
 
     def ready(self):
-        import devices.openapi  # noqa: F401 – register OpenAPI auth extension
+        import devices.openapi  # noqa: F401 - register OpenAPI auth extension

--- a/server/devices/auth.py
+++ b/server/devices/auth.py
@@ -22,8 +22,8 @@ class APIKeyAuthentication(authentication.BaseAuthentication):
 
             # Return user and key (DRF expects tuple of (user, auth))
             return (key_obj, api_key)
-        except APIKey.DoesNotExist:
-            raise exceptions.AuthenticationFailed("Invalid API key")
+        except APIKey.DoesNotExist as err:
+            raise exceptions.AuthenticationFailed("Invalid API key") from err
 
     def get_api_key(self, request):
         """Extract API key from request headers"""

--- a/server/devices/management/commands/seed_data.py
+++ b/server/devices/management/commands/seed_data.py
@@ -72,9 +72,7 @@ class Command(BaseCommand):
         self.stdout.write(
             self.style.SUCCESS("Successfully seeded database with sample data!")
         )
-        self.stdout.write(
-            self.style.SUCCESS("  Login: admin@esocore.local / admin")
-        )
+        self.stdout.write(self.style.SUCCESS("  Login: admin@esocore.local / admin"))
 
     def _clear_data(self):
         """Clear all seeded data."""
@@ -464,9 +462,7 @@ class Command(BaseCommand):
             FirmwareBundle.objects.get_or_create(
                 version=b["version"],
                 defaults={
-                    "hash": hashlib.sha256(
-                        b["version"].encode()
-                    ).hexdigest(),
+                    "hash": hashlib.sha256(b["version"].encode()).hexdigest(),
                     "channel": b["channel"],
                     "rollout_policy": b["rollout_policy"],
                     "supported_models": b["supported_models"],
@@ -485,9 +481,9 @@ class Command(BaseCommand):
                     device=device,
                     upload_id=upload_id,
                     defaults={
-                        "checksum": hashlib.sha256(
-                            str(upload_id).encode()
-                        ).hexdigest()[:64],
+                        "checksum": hashlib.sha256(str(upload_id).encode()).hexdigest()[
+                            :64
+                        ],
                         "status": "processed",
                         "record_count": random.randint(50, 200),
                         "processed_at": now - timedelta(hours=i * 6),
@@ -527,7 +523,9 @@ class Command(BaseCommand):
                             unit=unit,
                             meta={
                                 "sensor_id": f"{metric_name.split('_')[0]}_01",
-                                "sample_rate": 1000 if "vibration" in metric_name else 1,
+                                "sample_rate": (
+                                    1000 if "vibration" in metric_name else 1
+                                ),
                             },
                         )
                     )
@@ -823,10 +821,16 @@ class Command(BaseCommand):
                 "site": sites[0],
                 "layout": {"columns": 2, "rows": 3},
                 "widgets": [
-                    {"type": "stats_cards", "position": {"row": 0, "col": 0, "span": 2}},
+                    {
+                        "type": "stats_cards",
+                        "position": {"row": 0, "col": 0, "span": 2},
+                    },
                     {"type": "device_status_chart", "position": {"row": 1, "col": 0}},
                     {"type": "recent_alerts", "position": {"row": 1, "col": 1}},
-                    {"type": "telemetry_chart", "position": {"row": 2, "col": 0, "span": 2}},
+                    {
+                        "type": "telemetry_chart",
+                        "position": {"row": 2, "col": 0, "span": 2},
+                    },
                 ],
                 "is_default": True,
             },

--- a/server/devices/models.py
+++ b/server/devices/models.py
@@ -48,6 +48,9 @@ class Device(models.Model):
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
 
+    def __str__(self):
+        return f"{self.serial_number} ({self.model})"
+
     def set_api_secret(self, raw_secret: str) -> None:
         """Hash and store the API secret."""
         self.api_secret = hashlib.sha256(raw_secret.encode()).hexdigest()
@@ -56,9 +59,6 @@ class Device(models.Model):
         """Verify a raw secret against the stored hash (constant-time)."""
         candidate = hashlib.sha256(raw_secret.encode()).hexdigest()
         return hmac.compare_digest(candidate, self.api_secret)
-
-    def __str__(self):
-        return f"{self.serial_number} ({self.model})"
 
 
 class DeviceConfiguration(models.Model):

--- a/server/devices/tests.py
+++ b/server/devices/tests.py
@@ -1,14 +1,14 @@
 import uuid
 
 from django.contrib.auth.models import User
+from django.db import IntegrityError
 from django.test import TestCase
 from rest_framework import status
 from rest_framework.authtoken.models import Token
 from rest_framework.test import APIClient
 
 from .models import Device, DeviceConfiguration, FirmwareBundle, Site
-from .serializers import DeviceSerializer, FirmwareBundleSerializer, SiteSerializer
-
+from .serializers import DeviceSerializer, SiteSerializer
 
 # ---------------------------------------------------------------------------
 # Model tests
@@ -28,7 +28,7 @@ class SiteModelTests(TestCase):
 
     def test_unique_together(self):
         Site.objects.create(name="Factory A", customer=self.user)
-        with self.assertRaises(Exception):
+        with self.assertRaises(IntegrityError):
             Site.objects.create(name="Factory A", customer=self.user)
 
 
@@ -57,7 +57,7 @@ class DeviceModelTests(TestCase):
             api_secret="secret-001",
             site=self.site,
         )
-        with self.assertRaises(Exception):
+        with self.assertRaises(IntegrityError):
             Device.objects.create(
                 serial_number="SN-001",
                 model="Edge v2",

--- a/server/esocore_api/auth_views.py
+++ b/server/esocore_api/auth_views.py
@@ -1,3 +1,5 @@
+import contextlib
+
 from django.contrib.auth import authenticate
 from drf_spectacular.utils import OpenApiResponse, extend_schema, inline_serializer
 from rest_framework import serializers, status
@@ -89,17 +91,19 @@ def login_view(request):
 
 @extend_schema(
     request=None,
-    responses={200: inline_serializer(name="LogoutResponse", fields={"detail": serializers.CharField()})},
+    responses={
+        200: inline_serializer(
+            name="LogoutResponse", fields={"detail": serializers.CharField()}
+        )
+    },
     summary="Logout",
 )
 @api_view(["POST"])
 @permission_classes([IsAuthenticated])
 def logout_view(request):
     """Delete the current user's auth token."""
-    try:
+    with contextlib.suppress(Token.DoesNotExist):
         request.user.auth_token.delete()
-    except Token.DoesNotExist:
-        pass
     return Response({"detail": "Logged out."}, status=status.HTTP_200_OK)
 
 

--- a/server/esocore_api/dashboard_views.py
+++ b/server/esocore_api/dashboard_views.py
@@ -20,8 +20,12 @@ from events.models import SystemEvent
             "active_alerts": serializers.IntegerField(),
             "total_assets": serializers.IntegerField(),
             "total_sites": serializers.IntegerField(),
-            "device_status_breakdown": serializers.DictField(child=serializers.IntegerField()),
-            "alert_severity_breakdown": serializers.DictField(child=serializers.IntegerField()),
+            "device_status_breakdown": serializers.DictField(
+                child=serializers.IntegerField()
+            ),
+            "alert_severity_breakdown": serializers.DictField(
+                child=serializers.IntegerField()
+            ),
         },
     ),
     summary="Dashboard summary statistics",

--- a/server/esocore_api/settings.py
+++ b/server/esocore_api/settings.py
@@ -29,13 +29,17 @@ from .branding import ADMIN_TITLE  # noqa: E402
 # See https://docs.djangoproject.com/en/5.2/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = os.environ.get("SECRET_KEY", "django-insecure-dev-only-change-me-in-production")
+SECRET_KEY = os.environ.get(
+    "SECRET_KEY", "django-insecure-dev-only-change-me-in-production"
+)
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = os.environ.get("DEBUG", "False").lower() in ("true", "1", "yes")
 
 ALLOWED_HOSTS = [
-    h.strip() for h in os.environ.get("ALLOWED_HOSTS", "localhost,127.0.0.1").split(",") if h.strip()
+    h.strip()
+    for h in os.environ.get("ALLOWED_HOSTS", "localhost,127.0.0.1").split(",")
+    if h.strip()
 ]
 
 # Authentication backends (allow login by username or email)

--- a/server/events/tests.py
+++ b/server/events/tests.py
@@ -6,8 +6,7 @@ from rest_framework.test import APIClient
 
 from devices.models import Device, Site
 
-from .models import AlertRule, EventLog, NotificationQueue, SystemEvent
-
+from .models import AlertRule, SystemEvent
 
 # ---------------------------------------------------------------------------
 # Model tests
@@ -121,17 +120,13 @@ class SystemEventViewSetTests(TestCase):
         self.assertEqual(len(response.data["results"]), 1)
 
     def test_acknowledge_action(self):
-        response = self.client.post(
-            f"/api/events/events/{self.event.id}/acknowledge/"
-        )
+        response = self.client.post(f"/api/events/events/{self.event.id}/acknowledge/")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.event.refresh_from_db()
         self.assertEqual(self.event.status, "acknowledged")
 
     def test_resolve_action(self):
-        response = self.client.post(
-            f"/api/events/events/{self.event.id}/resolve/"
-        )
+        response = self.client.post(f"/api/events/events/{self.event.id}/resolve/")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.event.refresh_from_db()
         self.assertEqual(self.event.status, "resolved")

--- a/server/iot/views.py
+++ b/server/iot/views.py
@@ -69,16 +69,18 @@ def auth_handshake(request):
 
 
 @extend_schema(
-    request=serializers.ListSerializer(child=inline_serializer(
-        name="TelemetryItem",
-        fields={
-            "timestamp": serializers.CharField(),
-            "metric": serializers.CharField(),
-            "value": serializers.FloatField(),
-            "unit": serializers.CharField(required=False),
-            "meta": serializers.DictField(required=False),
-        },
-    )),
+    request=serializers.ListSerializer(
+        child=inline_serializer(
+            name="TelemetryItem",
+            fields={
+                "timestamp": serializers.CharField(),
+                "metric": serializers.CharField(),
+                "value": serializers.FloatField(),
+                "unit": serializers.CharField(required=False),
+                "meta": serializers.DictField(required=False),
+            },
+        )
+    ),
     responses={
         200: inline_serializer(
             name="TelemetryBatchResponse",
@@ -158,10 +160,7 @@ def telemetry_batch(request):
             try:
                 # Parse timestamp (expect ISO-8601 string)
                 ts = item.get("timestamp")
-                if isinstance(ts, str):
-                    ts_parsed = parse_datetime(ts)
-                else:
-                    ts_parsed = ts
+                ts_parsed = parse_datetime(ts) if isinstance(ts, str) else ts
                 if ts_parsed is None:
                     ts_parsed = timezone.now()
                 TelemetryPoint.objects.create(
@@ -283,9 +282,7 @@ def ota_check(request):
                 "release_notes": firmware.release_notes,
             }
         )
-    return Response(
-        {"available": False, "current_version": device.firmware_version}
-    )
+    return Response({"available": False, "current_version": device.firmware_version})
 
 
 @extend_schema(

--- a/server/manage.py
+++ b/server/manage.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 """Django's command-line utility for administrative tasks."""
+
 import os
 import sys
 

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -61,15 +61,19 @@ select = [
 ]
 
 ignore = [
-    "E501", # Line too long, let black handle this
-    "B008", # Do not perform function calls in argument defaults
-    "C901", # Too complex
+    "E501",   # Line too long, let black handle this
+    "B008",   # Do not perform function calls in argument defaults
+    "C901",   # Too complex
+    "PT009",  # unittest-style assertions are idiomatic in Django TestCase
+    "PT027",  # unittest-style assertRaises is idiomatic in Django TestCase
+    "RUF012", # Mutable class defaults are standard in Django models/serializers
 ]
 
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401"]
 "**/migrations/*.py" = ["E501", "N805"]
 "**/tests/*.py" = ["S101"]
+"scripts/*.py" = ["T201"]
 
 [tool.black]
 line-length = 88

--- a/server/scripts/format.py
+++ b/server/scripts/format.py
@@ -17,7 +17,7 @@ def run_command(cmd: list[str], description: str) -> bool:
     """Run a command and return True if successful."""
     print(f"🔧 {description}")
     try:
-        result = subprocess.run(cmd, check=True, capture_output=False, text=True)
+        subprocess.run(cmd, check=True, capture_output=False, text=True)
         print(f"✅ {description} completed")
         return True
     except subprocess.CalledProcessError as e:

--- a/server/scripts/lint.py
+++ b/server/scripts/lint.py
@@ -17,7 +17,7 @@ def run_command(cmd: list[str], description: str) -> bool:
     """Run a command and return True if successful."""
     print(f"🔍 {description}")
     try:
-        result = subprocess.run(cmd, check=True, capture_output=True, text=True)
+        subprocess.run(cmd, check=True, capture_output=True, text=True)
         print(f"✅ {description} passed")
         return True
     except subprocess.CalledProcessError as e:

--- a/server/telemetry/tests.py
+++ b/server/telemetry/tests.py
@@ -1,6 +1,7 @@
 import uuid
 
 from django.contrib.auth.models import User
+from django.db import IntegrityError
 from django.test import TestCase
 from django.utils import timezone
 from rest_framework import status
@@ -10,7 +11,6 @@ from rest_framework.test import APIClient
 from devices.models import Device, Site
 
 from .models import TelemetryPacket, TelemetryPoint, TelemetryWindow
-
 
 # ---------------------------------------------------------------------------
 # Model tests
@@ -44,7 +44,7 @@ class TelemetryPacketModelTests(TestCase):
         TelemetryPacket.objects.create(
             device=self.device, upload_id=upload_id, checksum="abc"
         )
-        with self.assertRaises(Exception):
+        with self.assertRaises(IntegrityError):
             TelemetryPacket.objects.create(
                 device=self.device, upload_id=upload_id, checksum="def"
             )

--- a/server/users/tests.py
+++ b/server/users/tests.py
@@ -4,10 +4,9 @@ from rest_framework import status
 from rest_framework.authtoken.models import Token
 from rest_framework.test import APIClient
 
-from devices.models import Device, Site
+from devices.models import Site
 
 from .models import Dashboard, UserDeviceRole, UserProfile
-
 
 # ---------------------------------------------------------------------------
 # Model tests
@@ -72,9 +71,7 @@ class UserProfileViewSetTests(TestCase):
         self.user = User.objects.create_user(username="testuser", password="pass1234")
         self.token = Token.objects.create(user=self.user)
         self.client.credentials(HTTP_AUTHORIZATION=f"Token {self.token.key}")
-        self.profile = UserProfile.objects.create(
-            user=self.user, company="Newmatik"
-        )
+        self.profile = UserProfile.objects.create(user=self.user, company="Newmatik")
 
     def test_list_own_profile(self):
         response = self.client.get("/api/users/profiles/")
@@ -157,13 +154,9 @@ class DashboardViewSetTests(TestCase):
         self.assertEqual(dashboard.user, self.user)
 
     def test_list_own_dashboards(self):
-        Dashboard.objects.create(
-            name="Dash 1", user=self.user, layout={}, widgets=[]
-        )
+        Dashboard.objects.create(name="Dash 1", user=self.user, layout={}, widgets=[])
         other = User.objects.create_user(username="other", password="pass1234")
-        Dashboard.objects.create(
-            name="Other Dash", user=other, layout={}, widgets=[]
-        )
+        Dashboard.objects.create(name="Other Dash", user=other, layout={}, widgets=[])
         response = self.client.get("/api/users/dashboards/")
         results = response.data["results"]
         self.assertEqual(len(results), 1)
@@ -252,7 +245,10 @@ class AuthViewTests(TestCase):
 
     def test_me_unauthenticated(self):
         response = self.client.get("/api/auth/me/")
-        self.assertIn(response.status_code, (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN))
+        self.assertIn(
+            response.status_code,
+            (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN),
+        )
 
     def test_logout(self):
         token = Token.objects.create(user=self.user)


### PR DESCRIPTION
## Summary
Fixes the remaining CI failures on main for Portal CI and Server CI workflows.

**Portal CI fixes:**
- Fix TypeScript type errors in `useApi.ts` (method type widening, body type mismatch with `$fetch`)
- Add `BadgeColor` type to 5 `.vue` files where `string` was not assignable to the Nuxt UI component's color prop union type
- Prettier formatting was already fixed in #19

**Server CI fixes:**
- Disable `PT009`/`PT027`/`RUF012` ruff rules that conflict with Django's idiomatic unittest-style test patterns and model class defaults
- Auto-fix import sorting (`I001`) and remove unused imports (`F401`)
- Fix remaining lint issues: `B017`, `B904`, `DJ012`, `RUF003`, `SIM105`, `SIM108`, `F841`
- Add per-file ignore for `T201` (print) in `scripts/` directory
- Run `black` to ensure consistent formatting after changes

## Test plan
- [ ] Portal CI passes (lint, format:check, typecheck, build)
- [ ] Server CI passes (ruff check, black check, isort check, tests)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved type safety across the application with stricter type definitions for API requests and badge colors.
  * Enhanced exception handling in authentication and data validation flows for more precise error reporting.

* **Tests**
  * Updated test assertions to verify correct exception types during constraint violations.

* **Chores**
  * Updated linting and code formatting configurations for improved code quality standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->