### PR TITLE
ci: make the CI checks safe to mark as required

### DIFF
--- a/.github/workflows/portal-ci.yml
+++ b/.github/workflows/portal-ci.yml
@@ -8,9 +8,6 @@ on:
       - ".github/workflows/portal-ci.yml"
   pull_request:
     branches: [main]
-    paths:
-      - "portal/**"
-      - ".github/workflows/portal-ci.yml"
 
 defaults:
   run:
@@ -18,6 +15,7 @@ defaults:
 
 jobs:
   build-and-lint:
+    name: Portal
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -8,9 +8,6 @@ on:
       - ".github/workflows/server-ci.yml"
   pull_request:
     branches: [main]
-    paths:
-      - "server/**"
-      - ".github/workflows/server-ci.yml"
 
 defaults:
   run:
@@ -18,6 +15,7 @@ defaults:
 
 jobs:
   lint:
+    name: Server lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -48,6 +46,7 @@ jobs:
         run: poetry run isort --check-only .
 
   test:
+    name: Server test
     runs-on: ubuntu-latest
     env:
       SECRET_KEY: test-secret-key-for-ci

--- a/.github/workflows/website-ci.yml
+++ b/.github/workflows/website-ci.yml
@@ -1,9 +1,11 @@
 name: Website CI
 
-# The website had no pull_request CI at all: portal-ci and server-ci are path-filtered to
-# their own directories, and pages.yml (which publishes the website) only runs on push to
-# main. So website/** changes reached main completely unchecked. pages.yml is included in
-# the paths below so a change to the publish workflow is validated by a real build first.
+# The website had no pull_request CI at all, so website/** changes reached main unchecked.
+#
+# The pull_request trigger is deliberately NOT path-filtered. A workflow skipped by a path
+# filter never reports its check run, so a required status check would sit pending forever
+# on any PR that doesn't touch website/. Push keeps its filter — required checks only apply
+# to PRs. pages.yml is in the push paths so a change to the publish workflow still rebuilds.
 on:
   push:
     branches: [main]
@@ -13,10 +15,6 @@ on:
       - ".github/workflows/pages.yml"
   pull_request:
     branches: [main]
-    paths:
-      - "website/**"
-      - ".github/workflows/website-ci.yml"
-      - ".github/workflows/pages.yml"
 
 defaults:
   run:
@@ -24,6 +22,7 @@ defaults:
 
 jobs:
   build-and-lint:
+    name: Website
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
Prerequisite for turning on required status checks in this repo. Two things had to change first.

**Path filters on `pull_request` are gone.** A workflow skipped by a path filter never reports its check run *at all* — it doesn't report "skipped", it reports **nothing** — so a required check would sit **pending forever** on any PR that doesn't touch that directory. That's a merge deadlock. (Job-level `if:` skips are fine, since those *do* report a conclusion.) `push` keeps its filters; required checks only apply to PRs.

**Job names are now distinct.** `portal-ci` and `website-ci` both emitted a check called `build-and-lint`. That's ambiguous as a required-check context — one passing job would satisfy the requirement even if the other never ran.

| Workflow | Check name |
|---|---|
| Portal CI | `Portal` |
| Website CI | `Website` |
| Server CI | `Server lint`, `Server test` |

Cost: every PR now runs all three CI workflows (~3 min total) instead of only the ones matching changed paths. That's the price of a required check that can't deadlock.